### PR TITLE
[#40] 멤버 알람 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ application.properties
 
 # Generated files
 src/main/generated/
+/src/main/resources/firebase-private-key.json

--- a/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
@@ -1,11 +1,13 @@
 package com.umc5th.muffler.domain.member.controller;
 
 import com.umc5th.muffler.domain.member.dto.AlarmAgreeUpdateRequest;
+import com.umc5th.muffler.domain.member.dto.TokenEnrollRequest;
 import com.umc5th.muffler.domain.member.service.MemberAlarmService;
 import com.umc5th.muffler.global.response.Response;
 import java.security.Principal;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,4 +24,11 @@ public class MemberAlarmController {
         memberAlarmService.fetchAlarmAgree(principal.getName(), request);
         return Response.success();
     }
+
+    @PutMapping("/token")
+    public Response<Void> enrollAlarmToken(Principal principal, @RequestBody @Valid TokenEnrollRequest request) {
+        memberAlarmService.enrollAlarmToken(principal.getName(), request);
+        return Response.success();
+    }
+
 }

--- a/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
@@ -31,4 +31,9 @@ public class MemberAlarmController {
         return Response.success();
     }
 
+    @DeleteMapping("/token")
+    public Response<Void> deleteAlarm(Principal principal) {
+        memberAlarmService.deleteAlarmToken(principal.getName());
+        return Response.success();
+    }
 }

--- a/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
@@ -1,0 +1,25 @@
+package com.umc5th.muffler.domain.member.controller;
+
+import com.umc5th.muffler.domain.member.dto.AlarmAgreeUpdateRequest;
+import com.umc5th.muffler.domain.member.service.MemberAlarmService;
+import com.umc5th.muffler.global.response.Response;
+import java.security.Principal;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/alarm")
+public class MemberAlarmController {
+    private final MemberAlarmService memberAlarmService;
+
+    @PutMapping("/agree")
+    public Response<Void> fetchAlarmAgree(Principal principal, @RequestBody @Valid AlarmAgreeUpdateRequest request) {
+        memberAlarmService.fetchAlarmAgree(principal.getName(), request);
+        return Response.success();
+    }
+}

--- a/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/controller/MemberAlarmController.java
@@ -8,6 +8,7 @@ import java.security.Principal;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,7 +26,7 @@ public class MemberAlarmController {
         return Response.success();
     }
 
-    @PutMapping("/token")
+    @PatchMapping("/token")
     public Response<Void> enrollAlarmToken(Principal principal, @RequestBody @Valid TokenEnrollRequest request) {
         memberAlarmService.enrollAlarmToken(principal.getName(), request);
         return Response.success();

--- a/src/main/java/com/umc5th/muffler/domain/member/dto/AlarmAgreeUpdateRequest.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/dto/AlarmAgreeUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.umc5th.muffler.domain.member.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AlarmAgreeUpdateRequest {
+    @NotNull private Boolean dailyPlanRemindAgree;
+    @NotNull private Boolean todayEnrollRemindAgree;
+    @NotNull private Boolean yesterdayEnrollRemindAgree;
+    @NotNull private Boolean goalEndRemindAgree;
+}

--- a/src/main/java/com/umc5th/muffler/domain/member/dto/MemberConverter.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/dto/MemberConverter.java
@@ -1,0 +1,19 @@
+package com.umc5th.muffler.domain.member.dto;
+
+import com.umc5th.muffler.entity.Member;
+import com.umc5th.muffler.entity.MemberAlarm;
+
+public class MemberConverter {
+    public static Member toEntity(Member member, AlarmAgreeUpdateRequest request) {
+        MemberAlarm memberAlarm = MemberAlarm.builder()
+                .id(member.getMemberAlarm().getId())
+                .isDailyPlanRemindAgree(request.getDailyPlanRemindAgree())
+                .isGoalEndReportRemindAgree(request.getGoalEndRemindAgree())
+                .isTodayEnrollRemindAgree(request.getTodayEnrollRemindAgree())
+                .isYesterdayEnrollRemindAgree(request.getYesterdayEnrollRemindAgree())
+                .token(member.getMemberAlarm().getToken())
+                .build();
+        member.setMemberAlarm(memberAlarm);
+        return member;
+    }
+}

--- a/src/main/java/com/umc5th/muffler/domain/member/dto/TokenEnrollRequest.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/dto/TokenEnrollRequest.java
@@ -1,11 +1,14 @@
 package com.umc5th.muffler.domain.member.dto;
 
 import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenEnrollRequest {
     @NotEmpty
     private String token;

--- a/src/main/java/com/umc5th/muffler/domain/member/dto/TokenEnrollRequest.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/dto/TokenEnrollRequest.java
@@ -1,0 +1,12 @@
+package com.umc5th.muffler.domain.member.dto;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenEnrollRequest {
+    @NotEmpty
+    private String token;
+}

--- a/src/main/java/com/umc5th/muffler/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/repository/MemberRepository.java
@@ -3,9 +3,13 @@ package com.umc5th.muffler.domain.member.repository;
 import com.umc5th.muffler.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByRefreshToken(String refreshToken);
+    @Query("select m from Member m join fetch m.memberAlarm where m.id = :memberId")
+    Optional<Member> findMemberFetchAlarm(@Param("memberId") String memberId);
 }

--- a/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
@@ -1,0 +1,24 @@
+package com.umc5th.muffler.domain.member.service;
+
+import com.umc5th.muffler.domain.member.dto.AlarmAgreeUpdateRequest;
+import com.umc5th.muffler.domain.member.dto.MemberConverter;
+import com.umc5th.muffler.domain.member.repository.MemberRepository;
+import com.umc5th.muffler.entity.Member;
+import com.umc5th.muffler.global.response.code.ErrorCode;
+import com.umc5th.muffler.global.response.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAlarmService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void fetchAlarmAgree(String memberId, AlarmAgreeUpdateRequest request) {
+        Member member = memberRepository.findMemberFetchAlarm(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        member = MemberConverter.toEntity(member, request);
+    }
+}

--- a/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
@@ -30,4 +30,10 @@ public class MemberAlarmService {
         member.enrollToken(request.getToken());
     }
 
+    @Transactional
+    public void deleteAlarmToken(String memberId) {
+        Member member = memberRepository.findMemberFetchAlarm(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        member.deleteToken();
+    }
 }

--- a/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
@@ -2,6 +2,7 @@ package com.umc5th.muffler.domain.member.service;
 
 import com.umc5th.muffler.domain.member.dto.AlarmAgreeUpdateRequest;
 import com.umc5th.muffler.domain.member.dto.MemberConverter;
+import com.umc5th.muffler.domain.member.dto.TokenEnrollRequest;
 import com.umc5th.muffler.domain.member.repository.MemberRepository;
 import com.umc5th.muffler.entity.Member;
 import com.umc5th.muffler.global.response.code.ErrorCode;
@@ -21,4 +22,12 @@ public class MemberAlarmService {
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
         member = MemberConverter.toEntity(member, request);
     }
+
+    @Transactional
+    public void enrollAlarmToken(String memberId, TokenEnrollRequest request) {
+        Member member = memberRepository.findMemberFetchAlarm(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        member.enrollToken(request.getToken());
+    }
+
 }

--- a/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
+++ b/src/main/java/com/umc5th/muffler/domain/member/service/MemberAlarmService.java
@@ -21,6 +21,7 @@ public class MemberAlarmService {
         Member member = memberRepository.findMemberFetchAlarm(memberId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
         member = MemberConverter.toEntity(member, request);
+        memberRepository.save(member);
     }
 
     @Transactional

--- a/src/main/java/com/umc5th/muffler/entity/Member.java
+++ b/src/main/java/com/umc5th/muffler/entity/Member.java
@@ -64,7 +64,8 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
     @Builder.Default
     private List<Category> categories = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(unique = true)
     private MemberAlarm memberAlarm;
 
     public void setRefreshToken(String refreshToken) {
@@ -84,7 +85,6 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
         this.categories.add(category);
     }
     public void setMemberAlarm(MemberAlarm memberAlarm) {
-        memberAlarm.setMember(this);
         this.memberAlarm = memberAlarm;
     }
     public void enrollToken(String token) {

--- a/src/main/java/com/umc5th/muffler/entity/Member.java
+++ b/src/main/java/com/umc5th/muffler/entity/Member.java
@@ -65,6 +65,9 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
     @Builder.Default
     private List<Category> categories = new ArrayList<>();
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private MemberAlarm memberAlarm;
+
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
@@ -81,7 +84,10 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
         category.setMember(this);
         this.categories.add(category);
     }
-
+    public void setMemberAlarm(MemberAlarm memberAlarm) {
+        memberAlarm.setMember(this);
+        this.memberAlarm = memberAlarm;
+    }
     @Override
     public boolean isNew() {
         return getCreatedAt() == null;

--- a/src/main/java/com/umc5th/muffler/entity/Member.java
+++ b/src/main/java/com/umc5th/muffler/entity/Member.java
@@ -6,7 +6,6 @@ import com.umc5th.muffler.entity.base.BaseTimeEntity;
 import com.umc5th.muffler.entity.constant.Role;
 import com.umc5th.muffler.entity.constant.SocialType;
 import com.umc5th.muffler.entity.constant.Status;
-import lombok.*;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.core.GrantedAuthority;
@@ -87,6 +86,9 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
     public void setMemberAlarm(MemberAlarm memberAlarm) {
         memberAlarm.setMember(this);
         this.memberAlarm = memberAlarm;
+    }
+    public void enrollToken(String token) {
+        memberAlarm.enrollToken(token);
     }
     @Override
     public boolean isNew() {

--- a/src/main/java/com/umc5th/muffler/entity/Member.java
+++ b/src/main/java/com/umc5th/muffler/entity/Member.java
@@ -90,6 +90,7 @@ public class Member extends BaseTimeEntity implements Persistable<String>, UserD
     public void enrollToken(String token) {
         memberAlarm.enrollToken(token);
     }
+    public void deleteToken() {memberAlarm.deleteToken();}
     @Override
     public boolean isNew() {
         return getCreatedAt() == null;

--- a/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
+++ b/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
@@ -16,7 +16,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -24,7 +23,6 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Getter
 @DynamicInsert
-@DynamicUpdate
 public class MemberAlarm extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,6 +54,11 @@ public class MemberAlarm extends BaseTimeEntity {
         this.member = member;
     }
     public void enrollToken(String token) {
-        this.token = token;
+        if (token != null) {
+            this.token = token;
+        }
+    }
+    public void deleteToken() {
+        this.token = null;
     }
 }

--- a/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
+++ b/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
@@ -3,15 +3,18 @@ package com.umc5th.muffler.entity;
 import com.umc5th.muffler.entity.base.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -33,8 +36,24 @@ public class MemberAlarm extends BaseTimeEntity {
 
     @Column(nullable = false)
     @ColumnDefault("true")
-    private Boolean isAgree;
+    private Boolean isDailyPlanRemindAgree;
 
-    @OneToOne
+    @Column(nullable = false)
+    @ColumnDefault("true")
+    private Boolean isTodayEnrollRemindAgree;
+
+    @Column(nullable = false)
+    @ColumnDefault("true")
+    private Boolean isYesterdayEnrollRemindAgree;
+
+    @Column(nullable = false)
+    @ColumnDefault("true")
+    private Boolean isGoalEndReportRemindAgree;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(unique = true)
     private Member member;
+    public void setMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
+++ b/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -55,5 +54,8 @@ public class MemberAlarm extends BaseTimeEntity {
     private Member member;
     public void setMember(Member member) {
         this.member = member;
+    }
+    public void enrollToken(String token) {
+        this.token = token;
     }
 }

--- a/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
+++ b/src/main/java/com/umc5th/muffler/entity/MemberAlarm.java
@@ -47,12 +47,8 @@ public class MemberAlarm extends BaseTimeEntity {
     @ColumnDefault("true")
     private Boolean isGoalEndReportRemindAgree;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(unique = true)
+    @OneToOne(mappedBy = "memberAlarm")
     private Member member;
-    public void setMember(Member member) {
-        this.member = member;
-    }
     public void enrollToken(String token) {
         if (token != null) {
             this.token = token;


### PR DESCRIPTION
### ✏️ Description

- Firebase cloud message 를 이용하기 위한 token을 서버에 등록하는 api 와 삭제하는 api
- 동의 여부를 바꾸는 api

</br>

### 🔑 Key Changes

- 알람 토큰 등록/해제
- member와 memberAlarm 과의 연관관계 메서드 추가
- member에서 memberAlarm의 토큰을 다루는 메서드 추가

</br>

### 🙏🏻 To Reviewers

- 원래는 2달 동안 사용 안하면 없애는 로직을 추가 해야 하는데 연동 테스트를 위해 간단히 구현했습니다.
- put mapping은 준 값 그대로 계속 밀어넣기 때문에 patch mapping 보다 낫다고 생각했습니다.
